### PR TITLE
Added Contributing MD link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repo consists of the Backend code of the project, the backend code is in [S
 * `.NET` as well
 
 ## Contributing
-* Go to [ontributing.md](./CONTRIBUTING.md)
+* Go to [Contributing.md](./CONTRIBUTING.md)
 
 ## Guidelines to setup
 1. Open your local CLI -

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repo consists of the Backend code of the project, the backend code is in [S
 * `.NET` as well
 
 ## Contributing
-* Go to `Contributing.md`
+* Go to [ontributing.md](./CONTRIBUTING.md)
 
 ## Guidelines to setup
 1. Open your local CLI -


### PR DESCRIPTION
Previously in `README.md`, There is simply written `Contributing.md` but without a link to it. This makes the contributor go up the directory and then click on contributing.md file. It would be nice to have a direct link to it.