### PR TITLE
Improvement - Call stackexchange tags API with all the entered tags.

### DIFF
--- a/src/helpers/investApi.js
+++ b/src/helpers/investApi.js
@@ -30,15 +30,15 @@ exports.fetchTagDesc = async (tags) => {
  */
 exports.prepareTags = (tags, response) => {
   const resp = [];
-  for(let i=0; i < tags.length; i++) {
 
-    const foundTag = response.length && response.find((t) => t.tag_name === tags[i].toLowerCase())
+  for(const tag of tags) {
+    const foundTag = response.length && response.find((t) => t.tag_name === tag.toLowerCase())
     const obj = {
-      tagname:tags[i],
+      tagname:tag,
       description:''
     }
     if(!foundTag) {
-        obj.description = `A ${tags[i]} is a keyword or term assigned to a piece of information`
+        obj.description = `A ${tag} is a keyword or term assigned to a piece of information`
     } else {
       obj.description = foundTag.excerpt
     }

--- a/src/helpers/investApi.js
+++ b/src/helpers/investApi.js
@@ -1,8 +1,8 @@
 const axios = require('axios');
 const constantsHolder = require('../constants');
 
-exports.fetchTagDesc = async (tag) => {
-  const url = `${constantsHolder.API_BASE_URL}/tags/${tag}/wikis?site=stackoverflow`;
+exports.fetchTagDesc = async (tags) => {
+  const url = `${constantsHolder.API_BASE_URL}/tags/${tags}/wikis?site=stackoverflow`;
 
   const options = {
     method: 'GET',
@@ -13,11 +13,36 @@ exports.fetchTagDesc = async (tag) => {
     json: true,
   };
 
-  return await axios
-    .get(url, options)
-    .then((response) => response.data.items[0].excerpt)
+  const response = await axios.get(url, options)
+    .then((json) => json.data.items)
     .catch((err) => {
       console.log('error:', err);
-      return `A ${tag} is a keyword or term assigned to a piece of information`;
-    });
+    })
+  
+  return response;
 };
+
+/**
+ * @description - This function preapares an array of objects to be inserted into tags schema
+ * @param {tags} - array of strings
+ * @param {response} - array of objects
+ * @returns {resp} - array of objects
+ */
+exports.prepareTags = (tags, response) => {
+  const resp = [];
+  for(let i=0; i < tags.length; i++) {
+
+    const foundTag = response.length && response.find((t) => t.tag_name === tags[i].toLowerCase())
+    const obj = {
+      tagname:tags[i],
+      description:''
+    }
+    if(!foundTag) {
+        obj.description = `A ${tags[i]} is a keyword or term assigned to a piece of information`
+    } else {
+      obj.description = foundTag.excerpt
+    }
+    resp.push(obj)
+  }
+  return resp;
+}

--- a/src/repositories/posts.repository.js
+++ b/src/repositories/posts.repository.js
@@ -58,20 +58,12 @@ exports.create = async (newPost, result) => {
       }
     }
 
-    let mapAllTagsWithoutDescString = '';
-
-    /**
+     /**
      * prepare a string of tags with ";" as delimeter
      * for eg:- [java, javascript] will become "java;javascript"
      */
-    for (let i = 0; i < mapAllTagsWithoutDesc.length; i++) {
-      if (i === mapAllTagsWithoutDesc.length - 1) {
-        mapAllTagsWithoutDescString += `${mapAllTagsWithoutDesc[i]}`
-      } else {
-        mapAllTagsWithoutDescString += `${mapAllTagsWithoutDesc[i]};`
-      }
-    }
-
+    const mapAllTagsWithoutDescString = mapAllTagsWithoutDesc.join(';');
+    
     const resp = await investApi.fetchTagDesc(mapAllTagsWithoutDescString)
     mapNewTags = investApi.prepareTags(mapAllTagsWithoutDesc, resp)
 

--- a/src/repositories/posts.repository.js
+++ b/src/repositories/posts.repository.js
@@ -34,7 +34,7 @@ exports.create = async (newPost, result) => {
 
     const mapAllTags = [];
     const mapAllTagsWithoutDesc = [];
-    const mapNewTags = [];
+    let mapNewTags = [];
 
     for (const item of tags) {
       const tag = await TagsModelSequelize.findOne({
@@ -58,14 +58,22 @@ exports.create = async (newPost, result) => {
       }
     }
 
-    for (const item of mapAllTagsWithoutDesc) {
-      const tagDescription = await investApi.fetchTagDesc(item);
+    let mapAllTagsWithoutDescString = '';
 
-      mapNewTags.push({
-        tagname: item,
-        description: tagDescription,
-      });
+    /**
+     * prepare a string of tags with ";" as delimeter
+     * for eg:- [java, javascript] will become "java;javascript"
+     */
+    for (let i = 0; i < mapAllTagsWithoutDesc.length; i++) {
+      if (i === mapAllTagsWithoutDesc.length - 1) {
+        mapAllTagsWithoutDescString += `${mapAllTagsWithoutDesc[i]}`
+      } else {
+        mapAllTagsWithoutDescString += `${mapAllTagsWithoutDesc[i]};`
+      }
     }
+
+    const resp = await investApi.fetchTagDesc(mapAllTagsWithoutDescString)
+    mapNewTags = investApi.prepareTags(mapAllTagsWithoutDesc, resp)
 
     const newCreatedTags = await TagsModelSequelize.bulkCreate(mapNewTags)
       .catch((error) => {


### PR DESCRIPTION
We were fetching missing tags from the stackexchange API one by one which adds up extra network latency and increases the response time of post creation API.
Now, we fetch all the missing tags from the stackexchange API in single network call.
 
Also attaching the screenshots below,

While creating the post with tags `go`, `dummykeyword`
![Screenshot from 2022-03-13 20-29-28](https://user-images.githubusercontent.com/22330286/158066096-4932c2be-197d-4890-88a5-64eb70a2a64e.png)

After post gets successfully created,
![Screenshot from 2022-03-13 20-30-58](https://user-images.githubusercontent.com/22330286/158066212-a3c630e9-4ddc-4e49-bca5-2219a2f742d0.png)

Database state,
![Screenshot from 2022-03-13 20-40-29](https://user-images.githubusercontent.com/22330286/158066261-af83ed3a-b253-451f-abb1-3d2eb12f8248.png)



